### PR TITLE
Remove maintenance badge on Rutie

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@
 ### Ruby
   * [d-unseductable/ruru](https://github.com/d-unseductable/ruru) — native Ruby extensions written in Rust and vice versa [<img src="https://api.travis-ci.org/d-unseductable/ruru.svg?branch=master">](https://travis-ci.org/d-unseductable/ruru)
   * [danielpclark/rutie](https://github.com/danielpclark/rutie) — official fork of d-unseductable/ruru [![Build Status](https://travis-ci.org/danielpclark/rutie.svg?branch=master)](https://travis-ci.org/danielpclark/rutie)
-[![Maintenance](https://img.shields.io/maintenance/yes/2018.svg)](https://github.com/danielpclark/rutie/commits/master)
   * [tildeio/helix](https://github.com/tildeio/helix) — native Ruby extensions written in Rust [<img src="https://api.travis-ci.org/tildeio/helix.svg?branch=master">](https://travis-ci.org/tildeio/helix)
 #### mruby
   * [anima-engine/mrusty](https://github.com/anima-engine/mrusty) — mruby safe bindings for Rust [<img src="https://api.travis-ci.org/anima-engine/mrusty.svg?branch=master">](https://travis-ci.org/anima-engine/mrusty)


### PR DESCRIPTION
Rutie is actively maintained but the badge of maintenance status will go stale every year that rolls around.  Either I the maintainer would need to update this here every year, or just do this PR to remove it.  Seeing as how I have no guarantee that future PRs would continue to be merged here in the years to come I think it's wiser if I simply remove it now.